### PR TITLE
PM: Allow disabling components per-device

### DIFF
--- a/core/res/res/values/lineage_config.xml
+++ b/core/res/res/values/lineage_config.xml
@@ -23,8 +23,13 @@
          true will use SystemClock.elapsedRealtimeNanos() to set timestamp. -->
     <bool name="config_useSystemClockforRotationSensor">false</bool>
 
-    <!-- The list of components which should be automatically disabled. -->
-    <string-array name="config_disabledComponents" translatable="false">
+    <!-- The list of components which should be automatically disabled for a specific device.
+         Note: this MUST not be used to randomly disable components, ask for approval first! -->
+    <string-array name="config_deviceDisabledComponents" translatable="false">
+    </string-array>
+
+    <!-- The list of components which should be automatically disabled for all devices. -->
+    <string-array name="config_globallyDisabledComponents" translatable="false">
     </string-array>
 
     <!-- The list of components which should be forced to be enabled. -->

--- a/core/res/res/values/lineage_symbols.xml
+++ b/core/res/res/values/lineage_symbols.xml
@@ -28,7 +28,8 @@
     <java-symbol type="bool" name="config_useSystemClockforRotationSensor" />
 
     <!-- Package Manager -->
-    <java-symbol type="array" name="config_disabledComponents" />
+    <java-symbol type="array" name="config_deviceDisabledComponents" />
+    <java-symbol type="array" name="config_globallyDisabledComponents" />
     <java-symbol type="array" name="config_forceEnabledComponents" />
 
     <!-- Privacy Guard -->

--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -3183,20 +3183,10 @@ public class PackageManagerService extends IPackageManager.Stub
 
             // Disable components marked for disabling at build-time
             mDisabledComponentsList = new ArrayList<ComponentName>();
-            for (String name : mContext.getResources().getStringArray(
-                    com.android.internal.R.array.config_disabledComponents)) {
-                ComponentName cn = ComponentName.unflattenFromString(name);
-                mDisabledComponentsList.add(cn);
-                Slog.v(TAG, "Disabling " + name);
-                String className = cn.getClassName();
-                PackageSetting pkgSetting = mSettings.mPackages.get(cn.getPackageName());
-                if (pkgSetting == null || pkgSetting.pkg == null
-                        || !pkgSetting.pkg.hasComponentClassName(className)) {
-                    Slog.w(TAG, "Unable to disable " + name);
-                    continue;
-                }
-                pkgSetting.disableComponentLPw(className, UserHandle.USER_OWNER);
-            }
+            disableComponents(mContext.getResources().getStringArray(
+                    com.android.internal.R.array.config_deviceDisabledComponents));
+            disableComponents(mContext.getResources().getStringArray(
+                    com.android.internal.R.array.config_globallyDisabledComponents));
 
             // Enable components marked for forced-enable at build-time
             for (String name : mContext.getResources().getStringArray(
@@ -3327,6 +3317,23 @@ public class PackageManagerService extends IPackageManager.Stub
         mInstaller.setWarnIfHeld(mPackages);
 
         Trace.traceEnd(TRACE_TAG_PACKAGE_MANAGER);
+    }
+
+    private void disableComponents(String[] components) {
+        // Disable components marked for disabling at build-time
+        for (String name : components) {
+            ComponentName cn = ComponentName.unflattenFromString(name);
+            mDisabledComponentsList.add(cn);
+            Slog.v(TAG, "Disabling " + name);
+            String className = cn.getClassName();
+            PackageSetting pkgSetting = mSettings.mPackages.get(cn.getPackageName());
+            if (pkgSetting == null || pkgSetting.pkg == null
+                    || !pkgSetting.pkg.hasComponentClassName(className)) {
+                Slog.w(TAG, "Unable to disable " + name);
+                continue;
+            }
+            pkgSetting.disableComponentLPw(className, UserHandle.USER_OWNER);
+        }
     }
 
     /**


### PR DESCRIPTION
* Introduce a new overlayable string-array
  "config_deviceDisabledComponents"
* This is equally used to disable components per-device, e.g.
  NearbyMessagingService
* At the same time, rename config_disabledComponents to
  config_globallyDisabledComponents to reflect the difference

Change-Id: Ieeec0788b063a33e8a2830dd95b239c99a58466f